### PR TITLE
Adjust trim_blocks to ansible

### DIFF
--- a/j2cli/cli.py
+++ b/j2cli/cli.py
@@ -49,7 +49,8 @@ class Jinja2TemplateRenderer(object):
             extensions=self.ENABLED_EXTENSIONS,
             loader=FilePathLoader(cwd),
             undefined=jinja2.Undefined if allow_undefined else jinja2.StrictUndefined,  # raise errors for undefineds?
-            keep_trailing_newline=True
+            keep_trailing_newline=True,
+            trim_blocks=True
         )
 
     def register_filters(self, filters):


### PR DESCRIPTION
Ansible is one of the most widely used tools which makes use of Jinja2. I think it would be great to adopt the behavior to trim blocks by default.